### PR TITLE
feat: `getWaybill` to retrieve pdf labels

### DIFF
--- a/js/shipment.js
+++ b/js/shipment.js
@@ -63,4 +63,23 @@ export const ShipmentAPI = superclass =>
             });
             return response;
         }
+
+        async getWaybill(trackingNumber, { format = "pdf", ...options } = {}) {
+            const url = this.shippingBaseUrl + "shipments/labels";
+            const response = await this.post(url, {
+                kwargs: { auth: "headers" },
+                ...options,
+                dataJ: {
+                    LabelRecoveryRequest: {
+                        TrackingNumber: String(trackingNumber),
+                        LabelSpecification: {
+                            LabelImageFormat: {
+                                Code: format.toUpperCase()
+                            }
+                        }
+                    }
+                }
+            });
+            return response;
+        }
     };


### PR DESCRIPTION
Retrieves the waybill or label in the desired format. This will be used to get the label in PDF.