### PR TITLE
feat: support pdf label creation

### DIFF
--- a/js/shipment.js
+++ b/js/shipment.js
@@ -65,7 +65,9 @@ export const ShipmentAPI = superclass =>
                 const waybill = await this.getWaybill(trackingNumber, { format: format });
                 const labelImage = waybill.LabelRecoveryResponse.LabelResults.LabelImage;
                 response.ShipmentResponse.ShipmentResults.PackageResults.ShippingLabel = {
-                    ImageFormat: format,
+                    ImageFormat: {
+                        Code: format
+                    },
                     GraphicImage: labelImage.GraphicImage
                 };
             }


### PR DESCRIPTION
The UPS API is very weak, one can't create labels in PDF format. Some clients might want that. This abstracts the logic for the API client user, by detecting the request is for a PDF, requesting a PNG instead and later using a different UPS endpoint to create a copy of the PNG label but in PDF.