### PR TITLE
fix: UPS codes for pickup

### DIFF
--- a/js/shipment.js
+++ b/js/shipment.js
@@ -1,17 +1,17 @@
 /*
  * The code representing an express shipment.
  */
-export const EXPRESS_SERVICE_CODE = "07";
+export const EXPRESS_SERVICE_CODE = "007";
 
 /*
  * The code representing a standard shipment.
  */
-export const STANDARD_SERVICE_CODE = "11";
+export const STANDARD_SERVICE_CODE = "011";
 
 /*
  * The code representing a saver shipment.
  */
-export const SAVER_SERVICE_CODE = "65";
+export const SAVER_SERVICE_CODE = "065";
 
 /*
  * The code representing a shipment that is

--- a/test/api/base.js
+++ b/test/api/base.js
@@ -6,7 +6,9 @@ describe("API", function() {
         const api = new ups.API();
         assert.strictEqual(Boolean(api.documentBaseUrl), true);
         assert.strictEqual(Boolean(api.locatorBaseUrl), true);
+        assert.strictEqual(Boolean(api.pickupBaseUrl), true);
         assert.strictEqual(Boolean(api.shippingBaseUrl), true);
         assert.strictEqual(Boolean(api.trackingBaseUrl), true);
+        assert.strictEqual(Boolean(api.trackingXmlBaseUrl), true);
     });
 });


### PR DESCRIPTION
Using a service code for the UPS Shipping API they expect two digits according to the docs. The Pickup API service codes used three digits....

I have tested using three digits for both APIs and it worked with all the codes changed. That being said, we can generalise and use 3 digit codes for both APIs.