### PR TITLE
docs: remove unused config var in this API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ The Javascript version of the UPS Shipping service.
 | **UPS_SHIPPING_BASE_URL**     | `str` | `https://onlinetools.ups.com/ship/v1807/`             | The base URL that is going to be used for Shipping API connections.           |
 | **UPS_TRACKING_BASE_URL**     | `str` | `https://onlinetools.ups.com/track/v1/`               | The base URL that is going to be used for Tracking API connections.           |
 | **UPS_TRACKING_XML_BASE_URL** | `str` | `https://onlinetools.ups.com/ups.app/xml/Track/`      | The base URL that is going to be used for Tracking XML-based API connections. |
-| **UPS_ACCOUNT**               | `str` | `None`                                                | The number of the UPS account to use.                                         |
 | **UPS_LICENSE**               | `str` | `None`                                                | The UPS API license to be used for authentication.                            |
 | **UPS_USERNAME**              | `str` | `None`                                                | The UPS API username to be used for authentication                            |
 | **UPS_PASSWORD**              | `str` | `None`                                                | The UPS API password to be used for authentication                            |


### PR DESCRIPTION
Issue: https://github.com/ripe-tech/peri-shipping/issues/74

Related: https://github.com/ripe-tech/peri-shipping/pull/78

`UPS_ACCOUNT` is unused by this API client. We do use it in PERI shipping to populate payloads, but it does not concern this API client.