### PR TITLE
version: 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 *
 
+## [1.0.1] - 2023-11-09
+
+### Added
+
+* `getTrackingUrl` for tracking API - [#36](https://github.com/ripe-tech/ups-api-js/issues/36)
+
 ## [1.0.0] - 2023-11-09
 
 ### Changed

--- a/js/tracking.js
+++ b/js/tracking.js
@@ -43,4 +43,15 @@ export const TrackingAPI = superclass =>
             const response = await this.get(url, options);
             return response;
         }
+
+        /**
+         * Gets the tracking URL given a tracking number.
+         *
+         * @param {String} trackingNumber The tracking number of the shipment/waybill.
+         * @returns {String} The tracking URL.
+         * @see https://www.ups.com/upsdeveloperkit?loc=en_US
+         */
+        getTrackingUrl(trackingNumber) {
+            return `https://www.ups.com/track?InquiryNumber1=${trackingNumber}`;
+        }
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ups-api",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "The RIPE UPS API client",
     "keywords": [
         "api",


### PR DESCRIPTION
### Added

* `getTrackingUrl` for tracking API - [#36](https://github.com/ripe-tech/ups-api-js/issues/36)