### PR TITLE
fix(paperless): add payload validation for document endpoints

### DIFF
--- a/js/paperless.js
+++ b/js/paperless.js
@@ -1,6 +1,5 @@
 export const SMALL_PACKAGE_SHIPMENT_TYPE = "1";
 export const FREIGHT_SHIPMENT_TYPE = "2";
-
 export const AUTH_FORM_DOC_TYPE = "001";
 export const INVOICE_DOC_TYPE = "002";
 export const CERTIFICATE_ORIGIN_DOC_TYPE = "003";
@@ -15,42 +14,53 @@ export const SED_DOC_TYPE = "011";
 export const LETTER_INSTRUCTION_DOC_TYPE = "012";
 export const DECLARATION_DOC_TYPE = "013";
 
-export const PaperlessAPI = superclass =>
-    class extends superclass {
-        /**
-         * Uploads a document to the UPS servers.
-         * The uploaded document is returned and its ID can be
-         * used to associate a shipment with the document.
-         *
-         * @param {Object} payload The payload object according to the UPS API standards.
-         * @param {Object} options An object of options to configure the request.
-         * @returns {Object} The HTTP response object.
-         * @see https://www.ups.com/upsdeveloperkit?loc=en_US
-         */
-        async createDocument(payload, options = {}) {
-            const url = `${this.baseUrl}paperlessdocuments/${this.version}/upload`;
-            const response = await this.post(url, {
-                ...options,
-                dataJ: { UploadRequest: payload }
-            });
-            return response;
-        }
 
-        /**
-         * Adds the already uploaded documents in the UPS servers to an
-         * existing shipment.
-         *
-         * @param {Object} payload The payload object according to the UPS API standards.
-         * @param {Object} options An object of options to configure the request.
-         * @returns {Object} The HTTP response object.
-         * @see https://www.ups.com/upsdeveloperkit?loc=en_US
-         */
-        async addDocumentShipment(payload, options = {}) {
-            const url = `${this.baseUrl}paperlessdocuments/${this.version}/image`;
-            const response = await this.post(url, {
-                ...options,
-                dataJ: { PushToImageRepositoryRequest: payload }
-            });
-            return response;
-        }
-    };
+export const PaperlessAPI = superclass =>
+   class extends superclass {
+      /**
+       * Uploads a document to the UPS servers.
+       * The uploaded document is returned and its ID can be
+       * used to associate a shipment with the document.
+       *
+       * @param {Object} payload The payload object according to the UPS API standards.
+       * @param {Object} options An object of options to configure the request.
+       * @returns {Object} The HTTP response object.
+       */
+      async createDocument(payload, options = {}) {
+         if (!payload || typeof payload !== "object") {
+            throw new Error("createDocument requires a valid payload object");
+         }
+
+         const url = `${this.baseUrl}paperlessdocuments/${this.version}/upload`;
+
+         return this.post(url, {
+            ...options,
+            dataJ: {
+               UploadRequest: payload
+            }
+         });
+      }
+
+      /**
+       * Adds the already uploaded documents in the UPS servers to an
+       * existing shipment.
+       *
+       * @param {Object} payload The payload object according to the UPS API standards.
+       * @param {Object} options An object of options to configure the request.
+       * @returns {Object} The HTTP response object.
+       */
+      async addDocumentShipment(payload, options = {}) {
+         if (!payload || typeof payload !== "object") {
+            throw new Error("addDocumentShipment requires a valid payload object");
+         }
+
+         const url = `${this.baseUrl}paperlessdocuments/${this.version}/image`;
+
+         return this.post(url, {
+            ...options,
+            dataJ: {
+               PushToImageRepositoryRequest: payload
+            }
+         });
+      }
+   };


### PR DESCRIPTION
- Validate payload before making API requests
- Throw descriptive errors for invalid payloads
- Prevent unnecessary calls to UPS Paperless API

### Issue
- https://github.com/ripe-tech/ups-api-js/issues/xxx

### Dependencies
- None

### Decisions
- None

### Screenshots
- None
